### PR TITLE
fix: auth using "user_key" or "service_account_id"

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -13,6 +13,7 @@ class Config {
       CLIENT_ID_ENV: 'CLIENT_ID',
       PASSWORD_ENV: 'PASSWORD',
       USER_KEY_ENV: 'USER_KEY',
+      SERVICE_ACCOUNT_ID_ENV: 'SERVICE_ACCOUNT_ID',
       SUBSCRIPTION_ID_ENV: 'SUBSCRIPTION_ID',
       EXTRACTION_API_HOST_ENV: 'EXTRACTION_API_HOST',
       EXTRACTION_API_HOST_DEFAULT: 'https://api.dowjones.com',
@@ -56,6 +57,11 @@ class Config {
       }
     }
 
+    // NOTE: "service_account_id" is a legacy, alternate name for "user_key" from the customer's perspective
+    if (!accountCreds.user_key && accountCreds.service_account_id) {
+      accountCreds.user_key = accountCreds.service_account_id;
+    }
+
     return this._areCredsSet(accountCreds) ? accountCreds : new Error(
       'Error: No account credentials specified\n' +
       'Must specify user_id, client_id, and password as args to Listener constructor, env vars, or via customerConfig.json file\n' +
@@ -68,12 +74,13 @@ class Config {
       user_id: process.env[this.Constants.USER_ID_ENV],
       client_id: process.env[this.Constants.CLIENT_ID_ENV],
       password: process.env[this.Constants.PASSWORD_ENV],
-      user_key: process.env[this.Constants.USER_KEY_ENV]
+      user_key: process.env[this.Constants.USER_KEY_ENV],
+      service_account_id: process.env[this.Constants.SERVICE_ACCOUNT_ID_ENV]
     };
   }
 
   _areCredsSet(accountCreds) {
-    return accountCreds && (accountCreds.user_key || (accountCreds.user_id && accountCreds.client_id && accountCreds.password));
+    return accountCreds && (accountCreds.user_key || accountCreds.service_account_id || (accountCreds.user_id && accountCreds.client_id && accountCreds.password));
   }
 }
 

--- a/config/ConfigFileUtil.js
+++ b/config/ConfigFileUtil.js
@@ -47,6 +47,7 @@ class ConfigFileUtil {
 
     return {
       user_key: _.trim(this.config.user_key),
+      service_account_id: _.trim(this.config.service_account_id),
       user_id: _.trim(this.config.user_id),
       client_id: _.trim(this.config.client_id),
       password: _.trim(this.config.password)

--- a/tests/config/testCustomerConfigServiceAccountId.json
+++ b/tests/config/testCustomerConfigServiceAccountId.json
@@ -1,0 +1,7 @@
+{
+  "service_account_id": "foo",
+  "user_id": "account@account.com",
+  "client_id": "clientID123",
+  "password": "Password123",
+  "subscription_id": "bar"
+}

--- a/tests/configFileUtilTests.js
+++ b/tests/configFileUtilTests.js
@@ -6,6 +6,7 @@ const path = require('path');
 describe('configFileUtil', () => {
   let sandbox;
   const pathConfig = path.join(__dirname, './config/testCustomerConfig.json');
+  const serviceAccountIdPathConfig = path.join(__dirname, './config/testCustomerConfigServiceAccountId.json');
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -23,6 +24,19 @@ describe('configFileUtil', () => {
     // Act
     const creds = configFileUtil.getAccountCredentials();
     const userKey = creds.user_key;
+
+    // Assert
+    expect(userKey).toBe('foo');
+  });
+
+  it('should get the correct customer user key when set with service_account_id param.', () => {
+    // Arrange
+    const configFileUtil = new ConfigFileUtil();
+    configFileUtil.setConfigFilePath(serviceAccountIdPathConfig);
+
+    // Act
+    const creds = configFileUtil.getAccountCredentials();
+    const userKey = creds.service_account_id;
 
     // Assert
     expect(userKey).toBe('foo');

--- a/tests/configTests.js
+++ b/tests/configTests.js
@@ -49,6 +49,19 @@ describe('config', () => {
     expect(actualUserKey).toBe(expectedUserKey);
   });
 
+  it('should prioritize service_account_id from env over service account creds in config file', () => {
+    // Arrange
+    const expectedUserKey = '123A';
+    process.env[config.Constants.SERVICE_ACCOUNT_ID_ENV] = expectedUserKey;
+
+    // Act
+    const creds = config.getAccountCredentials();
+    const actualUserKey = creds.user_key;
+
+    // Assert
+    expect(actualUserKey).toBe(expectedUserKey);
+  });
+
   it('should prioritize credentials set thru env vars over config file', () => {
     // Arrange
     const expectedUserId = 'userId';
@@ -99,6 +112,20 @@ describe('config', () => {
     // Arrange
     const userKeyExpected = '123';
     const configSpecial = new Config({ user_key: userKeyExpected });
+
+    // Act
+    const accountCreds = configSpecial.getAccountCredentials();
+    const userKeyActual = accountCreds.user_key;
+
+    // Assert
+    expect(userKeyExpected).toBe(userKeyActual);
+    expect(accountCreds.user_id).toBe(undefined);
+  });
+
+  it('should prioritize service_account_id param over service account credentials in config file', () => {
+    // Arrange
+    const userKeyExpected = '123';
+    const configSpecial = new Config({ service_account_id: userKeyExpected });
 
     // Act
     const accountCreds = configSpecial.getAccountCredentials();


### PR DESCRIPTION
What does this PR do?
It allows users to use either the parameter "service_account_id" or "user_key" to set their user_key for the user_key authentication flow (as either a param to the listener, an env var, or an entry in the customerConfig.json). This is to guarantee that any customers who may have been using either of these two parameter names will not have their workflow broken.

How should this be manually tested?
Run the streaming client by setting the "user_key" param to some valid user_key value. Authentication should work successfully. Rerun the client without the "user_key" param but with the "service_account_id" param set to the same value. Authentication should again work successfully for the same account.

What are the relevant tickets?
https://trello.com/c/MZU20Mtq/1377-as-a-user-of-the-streaming-clients-i-want-to-be-able-to-authenticate-with-both-serviceaccountid-and-userkey-param-names-for-the

Checklist
  I added the necessary documentation, if appropriate.
  I added tests to prove that my fix is effective or my feature works.
  I reviewed existing Pull Requests before submitting mine.