### PR TITLE
only call get stream on start up

### DIFF
--- a/Listener.js
+++ b/Listener.js
@@ -123,10 +123,8 @@ class Listener {
       if (isDisabled) {
         console.error(streamDisabledMsg);
       }
-      setTimeout(this.checkDocCountExceeded.bind(this), interval, subscriptionId, maxDocumentsReceived);
     }).catch((err) => {
       console.error(err);
-      setTimeout(this.checkDocCountExceeded.bind(this), interval, subscriptionId, maxDocumentsReceived);
     });
   }
 }


### PR DESCRIPTION
Very simple, reduces the number of API calls to the Factiva Analytics snapshots and stream API by only checking article usage on start up. This makes the Node JS listener match the behavior of the Python listener when it comes to checking for article usage.